### PR TITLE
Update hotspot stream controller when view is updated

### DIFF
--- a/lib/panorama.dart
+++ b/lib/panorama.dart
@@ -261,6 +261,7 @@ class _PanoramaState extends State<Panorama> with SingleTickerProviderStateMixin
     q.rotate(scene!.camera.target..setFrom(Vector3(0, 0, -_radius)));
     q.rotate(scene!.camera.up..setFrom(Vector3(0, 1, 0)));
     scene!.update();
+    _streamController.add(null);
   }
 
   void _updateSensorControl() {


### PR DESCRIPTION
The hotspots in my Panorama widget are not showing when first starting the app, but only after doing a hot reload. I found out this is because on line 361 of panorama.dart there is a check for `scene != null`, and so at the start of the app the scene was not yet created for me and therefore no hotspots are created (when I do a hot reload the scene already exists so the hotspots are created).

Another problem I found is that the hotspots do not update their position when the camera view changes (when the user moves the camera around). This line of code solves both problems for me (i.e. hotspot is not showing at beginning, and hotspots do not update position).