### PR TITLE
Fix to prevent the AnimationController from stopping if a sensorControl is active

### DIFF
--- a/lib/panorama.dart
+++ b/lib/panorama.dart
@@ -211,8 +211,12 @@ class _PanoramaState extends State<Panorama> with SingleTickerProviderStateMixin
     zoomDelta *= 1 - _dampingFactor;
     scene!.camera.zoom = zoom.clamp(widget.minZoom, widget.maxZoom);
     // stop animation if not needed
-    if (latitudeDelta.abs() < 0.001 && longitudeDelta.abs() < 0.001 && zoomDelta.abs() < 0.001) {
-      if (widget.animSpeed == 0 && _controller.isAnimating) _controller.stop();
+    if (latitudeDelta.abs() < 0.001 &&
+        longitudeDelta.abs() < 0.001 &&
+        zoomDelta.abs() < 0.001) {
+      if (widget.sensorControl == SensorControl.None &&
+          widget.animSpeed == 0 &&
+          _controller.isAnimating) _controller.stop();
     }
 
     // rotate for screen orientation


### PR DESCRIPTION
I found that if I was setting sensorControl on the Panorama class, to the following...
`sensorControl: SensorControl.AbsoluteOrientation,`
AND animSpeed to 0, the tracking wasn't working.

I discovered that the AnimationController was being stopped prematurely in my case, so I added a check to make sure
`widget.sensorControl == SensorControl.None`
before the AnimationController is stopped.